### PR TITLE
Update wishart.cpp

### DIFF
--- a/src/wishart.cpp
+++ b/src/wishart.cpp
@@ -22,7 +22,7 @@ arma::cube rwishartArma(const int n,
                         const arma::mat & sigma, 
                         const double nu) {
   const int p = sigma.n_cols;
-  const arma::mat L = arma::chol(sigma);
+  const arma::mat L = arma::chol(sigma, "lower");
   arma::cube ans(p, p, n);
   for (int k = 0; k < n; ++k) {
     ans.slice(k) = rwishartS(L, nu, p);
@@ -35,7 +35,7 @@ arma::cube rinvwishartArma(const int n,
                            const arma::mat & psi, 
                            const double nu) {
   const int p = psi.n_cols ;
-  const arma::mat L = arma::chol(inv(psi));
+  const arma::mat L = arma::chol(inv(psi), "lower");
   arma::cube ans(p, p, n);
   for (int k = 0; k < n; ++k) {
     ans.slice(k) = inv(rwishartS(L, nu, p));


### PR DESCRIPTION
The Barttlett decomposition for sampling from a wishart distribution used here requires the lower triangular matrix from the cholesky decomposition of psi, but the default behavior of arma::chol is according to the documentation to return the upper triangular matrix.